### PR TITLE
Find newer versions

### DIFF
--- a/cmake/FindCryptoPP.cmake
+++ b/cmake/FindCryptoPP.cmake
@@ -65,18 +65,16 @@ if(CryptoPP_VERSION_HEADER)
 
     string(REGEX MATCHALL "#define[ \\t\\r\\n]+CRYPTOPP_REVISION[ \\t\\r\\n]+([0-9]+)" _ "${version_content}")
     set(CryptoPP_VERSION_PATCH ${CMAKE_MATCH_1})
-
-    set(CryptoPP_VERSION "${CryptoPP_VERSION_MAJOR}.${CryptoPP_VERSION_MINOR}.${CryptoPP_VERSION_PATCH}")
-    set(CryptoPP_VERSION_${CryptoPP_VERSION_MAJOR} TRUE)
 elseif(CryptoPP_INCLUDE_DIR)
     file(STRINGS ${CryptoPP_INCLUDE_DIR}/cryptopp/config.h _config_version REGEX "CRYPTOPP_VERSION")
     string(REGEX MATCH "([0-9]+)([0-9]+)([0-9]+)" _match_version ${_config_version})
     set(CryptoPP_VERSION_MAJOR ${CMAKE_MATCH_1})
     set(CryptoPP_VERSION_MINOR ${CMAKE_MATCH_2})
     set(CryptoPP_VERSION_PATCH ${CMAKE_MATCH_3})
-    set(CryptoPP_VERSION "${CryptoPP_VERSION_MAJOR}.${CryptoPP_VERSION_MINOR}.${CryptoPP_VERSION_PATCH}")
-    set(CryptoPP_VERSION_${CryptoPP_VERSION_MAJOR} TRUE)
 endif()
+
+set(CryptoPP_VERSION "${CryptoPP_VERSION_MAJOR}.${CryptoPP_VERSION_MINOR}.${CryptoPP_VERSION_PATCH}")
+set(CryptoPP_VERSION_${CryptoPP_VERSION_MAJOR} TRUE)
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(CryptoPP

--- a/cmake/FindCryptoPP.cmake
+++ b/cmake/FindCryptoPP.cmake
@@ -25,6 +25,11 @@ if (CryptoPP_ROOT_DIR)
         NO_DEFAULT_PATH
         PATHS ${CryptoPP_ROOT_DIR}/include
         )
+    find_file(CryptoPP_VERSION_HEADER
+        NAMES cryptopp/config_ver.h
+        NO_DEFAULT_PATH
+        PATHS ${CryptoPP_ROOT_DIR}/include
+    )
     find_library(CryptoPP_LIBRARY
         NAMES cryptopp
         DOC "CryptoPP library"
@@ -37,6 +42,9 @@ else()
         NAMES cryptopp/config.h
         DOC "CryptoPP include directory"
         )
+    find_file(CryptoPP_VERSION_HEADER
+        NAMES cryptopp/config_ver.h
+    )
     find_library(CryptoPP_LIBRARY
         NAMES cryptopp
         DOC "CryptoPP library"
@@ -46,7 +54,21 @@ else()
     message("PACZPAN without root given: ${CryptoPP_INCLUDE_DIR} ${CryptoPP_LIBRARY}")
 endif(CryptoPP_ROOT_DIR)
 
-if(CryptoPP_INCLUDE_DIR)
+if(CryptoPP_VERSION_HEADER)
+    file(READ ${CryptoPP_VERSION_HEADER} version_content)
+
+    string(REGEX MATCHALL "#define[ \\t\\r\\n]+CRYPTOPP_MAJOR[ \\t\\r\\n]+([0-9]+)" _ "${version_content}")
+    set(CryptoPP_VERSION_MAJOR ${CMAKE_MATCH_1})
+
+    string(REGEX MATCHALL "#define[ \\t\\r\\n]+CRYPTOPP_MINOR[ \\t\\r\\n]+([0-9]+)" _ "${version_content}")
+    set(CryptoPP_VERSION_MINOR ${CMAKE_MATCH_1})
+
+    string(REGEX MATCHALL "#define[ \\t\\r\\n]+CRYPTOPP_REVISION[ \\t\\r\\n]+([0-9]+)" _ "${version_content}")
+    set(CryptoPP_VERSION_PATCH ${CMAKE_MATCH_1})
+
+    set(CryptoPP_VERSION "${CryptoPP_VERSION_MAJOR}.${CryptoPP_VERSION_MINOR}.${CryptoPP_VERSION_PATCH}")
+    set(CryptoPP_VERSION_${CryptoPP_VERSION_MAJOR} TRUE)
+elseif(CryptoPP_INCLUDE_DIR)
     file(STRINGS ${CryptoPP_INCLUDE_DIR}/cryptopp/config.h _config_version REGEX "CRYPTOPP_VERSION")
     string(REGEX MATCH "([0-9]+)([0-9]+)([0-9]+)" _match_version ${_config_version})
     set(CryptoPP_VERSION_MAJOR ${CMAKE_MATCH_1})
@@ -74,3 +96,5 @@ set(CryptoPP_INCLUDE_DIRS ${CryptoPP_INCLUDE_DIR})
 set(CryptoPP_LIBRARIES ${CryptoPP_LIBRARY})
 set(CryptoPP_VERSION_STRING ${CryptoPP_VERSION})
 
+# Clean-up variables
+unset(CryptoPP_VERSION_HEADER)

--- a/cmake/FindCryptoPP.cmake
+++ b/cmake/FindCryptoPP.cmake
@@ -13,6 +13,7 @@ CryptoPP_VERSION     - The version of the library
 CryptoPP_VERSION_MAJOR - The major version of the library
 CryptoPP_VERSION_MINOR - The minor version of the library
 CryptoPP_VERSION_PATCH - The patch version (revision) of the library
+CryptoPP_VERSION_VV  - Whether or not version VV has been found
 CryptoPP_VERSION_STRING - The version of the library (for compatability, use CryptoPP_VERSION instead)
 ]]
 
@@ -52,6 +53,7 @@ if(CryptoPP_INCLUDE_DIR)
     set(CryptoPP_VERSION_MINOR ${CMAKE_MATCH_2})
     set(CryptoPP_VERSION_PATCH ${CMAKE_MATCH_3})
     set(CryptoPP_VERSION "${CryptoPP_VERSION_MAJOR}.${CryptoPP_VERSION_MINOR}.${CryptoPP_VERSION_PATCH}")
+    set(CryptoPP_VERSION_${CryptoPP_VERSION_MAJOR} TRUE)
 endif()
 
 include(FindPackageHandleStandardArgs)

--- a/cmake/FindCryptoPP.cmake
+++ b/cmake/FindCryptoPP.cmake
@@ -10,6 +10,9 @@ CryptoPP::CryptoPP   - target (release build)
 CryptoPP_INCLUDE_DIR - includes directory containing subdirectory cryptopp/
 CryptoPP_LIBRARY     - CryptoPP library file (libcryptopp.a)
 CryptoPP_VERSION     - The version of the library
+CryptoPP_VERSION_MAJOR - The major version of the library
+CryptoPP_VERSION_MINOR - The minor version of the library
+CryptoPP_VERSION_PATCH - The patch version (revision) of the library
 CryptoPP_VERSION_STRING - The version of the library (for compatability, use CryptoPP_VERSION instead)
 ]]
 
@@ -45,7 +48,10 @@ endif(CryptoPP_ROOT_DIR)
 if(CryptoPP_INCLUDE_DIR)
     file(STRINGS ${CryptoPP_INCLUDE_DIR}/cryptopp/config.h _config_version REGEX "CRYPTOPP_VERSION")
     string(REGEX MATCH "([0-9]+)([0-9]+)([0-9]+)" _match_version ${_config_version})
-    set(CryptoPP_VERSION "${CMAKE_MATCH_1}.${CMAKE_MATCH_2}.${CMAKE_MATCH_3}")
+    set(CryptoPP_VERSION_MAJOR ${CMAKE_MATCH_1})
+    set(CryptoPP_VERSION_MINOR ${CMAKE_MATCH_2})
+    set(CryptoPP_VERSION_PATCH ${CMAKE_MATCH_3})
+    set(CryptoPP_VERSION "${CryptoPP_VERSION_MAJOR}.${CryptoPP_VERSION_MINOR}.${CryptoPP_VERSION_PATCH}")
 endif()
 
 include(FindPackageHandleStandardArgs)

--- a/cmake/FindCryptoPP.cmake
+++ b/cmake/FindCryptoPP.cmake
@@ -9,6 +9,8 @@ Output:
 CryptoPP::CryptoPP   - target (release build)
 CryptoPP_INCLUDE_DIR - includes directory containing subdirectory cryptopp/
 CryptoPP_LIBRARY     - CryptoPP library file (libcryptopp.a)
+CryptoPP_VERSION     - The version of the library
+CryptoPP_VERSION_STRING - The version of the library (for compatability, use CryptoPP_VERSION instead)
 ]]
 
 if (CryptoPP_ROOT_DIR)
@@ -43,14 +45,14 @@ endif(CryptoPP_ROOT_DIR)
 if(CryptoPP_INCLUDE_DIR)
     file(STRINGS ${CryptoPP_INCLUDE_DIR}/cryptopp/config.h _config_version REGEX "CRYPTOPP_VERSION")
     string(REGEX MATCH "([0-9]+)([0-9]+)([0-9]+)" _match_version ${_config_version})
-    set(CryptoPP_VERSION_STRING "${CMAKE_MATCH_1}.${CMAKE_MATCH_2}.${CMAKE_MATCH_3}")
+    set(CryptoPP_VERSION "${CMAKE_MATCH_1}.${CMAKE_MATCH_2}.${CMAKE_MATCH_3}")
 endif()
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(CryptoPP
     REQUIRED_VARS CryptoPP_INCLUDE_DIR CryptoPP_LIBRARY
     FOUND_VAR CryptoPP_FOUND
-    VERSION_VAR CryptoPP_VERSION_STRING)
+    VERSION_VAR CryptoPP_VERSION)
 
 if(CryptoPP_FOUND AND NOT TARGET CryptoPP::CryptoPP)
     add_library(CryptoPP::CryptoPP UNKNOWN IMPORTED)
@@ -62,4 +64,5 @@ endif()
 mark_as_advanced(CryptoPP_INCLUDE_DIR CryptoPP_LIBRARY)
 set(CryptoPP_INCLUDE_DIRS ${CryptoPP_INCLUDE_DIR})
 set(CryptoPP_LIBRARIES ${CryptoPP_LIBRARY})
+set(CryptoPP_VERSION_STRING ${CryptoPP_VERSION})
 


### PR DESCRIPTION
Since CryptoPP 8.3.0 (see weidai11/cryptopp#836), the version is contained within `config_ver.h`. I left the previous handling in for versions in `config.h`. It is also easier to parse out the major, minor, and patch versions through macros `CRYPTOPP_<MAJOR|MINOR|REVISION>`.

I've also included some patches to bring the find module up to newer CMake find module standards, see [cmake-developer(7)](https://cmake.org/cmake/help/latest/manual/cmake-developer.7.html#standard-variable-names).